### PR TITLE
Update quickstart notebook for multi-metric plots

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -142,25 +142,7 @@
    "cell_type": "markdown",
    "id": "068l5vzze2nr",
    "metadata": {},
-   "source": [
-    "## 3. Inspect Results\n",
-    "\n",
-    "### 3.1 Pareto Front\n",
-    "\n",
-    "The optimization minimizes *two* objectives simultaneously:\n",
-    "- **Objective 0** — calibration error (lower = better-calibrated posterior approximation),\n",
-    "- **Objective 1** — normalized parameter count (lower = smaller model).\n",
-    "\n",
-    "These objectives trade off against each other: a very large network may achieve low calibration error but is expensive to run. The **Pareto front** shows the set of trials that are not dominated — no other trial is simultaneously smaller *and* better calibrated.\n",
-    "\n",
-    "### 3.2 Hyperparameter Importance\n",
-    "\n",
-    "After all trials have run, Optuna's **fANOVA-based importance estimator** assigns each hyperparameter a score reflecting how much its variation explains the variance in objective 0 (calibration error). High-importance hyperparameters are worth tuning carefully in follow-up studies.\n",
-    "\n",
-    "### 3.3 Optimization History\n",
-    "\n",
-    "The convergence plot shows how the best objective value evolves over successive trials. A healthy HPO run should trend downward — if it plateaus early, more trials won't help and you should widen the search space instead."
-   ]
+   "source": "## 3. Inspect Results\n\n### Figure 1 — Overview (2x2)\n\n| Panel | What it shows |\n|-------|--------------|\n| **Pareto front** | First objective vs actual parameter count. Red stars mark non-dominated trials. |\n| **Metric scatter** | Pairwise view of calibration error vs NRMSE. Points are colored by their mean value; the red step-line traces the 2D Pareto front across these two metrics. |\n| **Optimization history** | Convergence of the first objective over successive trials. The red step-line tracks the running best. |\n| **Param importance** | fANOVA-based importance scores showing which hyperparameters most affect the first objective. |\n\n### Figure 2 — Per-Metric Panels (1x2)\n\nPer-metric views decompose the composite objective to show how each metric individually trades off against model size. Each panel plots one metric (y) vs parameter count (x, log scale), with its own 2D Pareto front."
   },
   {
    "cell_type": "code",
@@ -175,37 +157,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "fig, axes = plt.subplots(1, 3, figsize=(18, 5))\n",
-    "\n",
-    "# 3.1 Pareto front: calibration error vs parameter count\n",
-    "hpo.plot_pareto_front(study, ax=axes[0])\n",
-    "\n",
-    "# 3.2 Hyperparameter importance (fANOVA)\n",
-    "hpo.plot_param_importance(study, ax=axes[1])\n",
-    "\n",
-    "# 3.3 Optimization history: best calibration error over trials\n",
-    "trained = [\n",
-    "    t for t in study.trials\n",
-    "    if t.values is not None and \"rejected_reason\" not in t.user_attrs\n",
-    "]\n",
-    "if trained:\n",
-    "    trained.sort(key=lambda t: t.number)\n",
-    "    trial_nums = [t.number for t in trained]\n",
-    "    cal_errors = [t.values[0] for t in trained]\n",
-    "    best_so_far = [min(cal_errors[: i + 1]) for i in range(len(cal_errors))]\n",
-    "    axes[2].scatter(trial_nums, cal_errors, alpha=0.4, label=\"Trial\")\n",
-    "    axes[2].step(trial_nums, best_so_far, where=\"post\", color=\"red\", label=\"Best so far\")\n",
-    "    axes[2].set_xlabel(\"Trial number\")\n",
-    "    axes[2].set_ylabel(\"Calibration error\")\n",
-    "    axes[2].set_title(\"Optimization history\")\n",
-    "    axes[2].legend()\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
+   "source": "import matplotlib.pyplot as plt\n\n# --- Figure 1: Overview (2x2) ---\nfig, axes = plt.subplots(2, 2, figsize=(14, 10))\n\nhpo.plot_pareto_front(study, ax=axes[0, 0])\nhpo.plot_metric_scatter(study, \"calibration_error\", \"nrmse\", ax=axes[0, 1])\nhpo.plot_optimization_history(study, ax=axes[1, 0])\nhpo.plot_param_importance(study, ax=axes[1, 1])\n\nfig.tight_layout()\nplt.show()\n\n# --- Figure 2: Per-metric panels (1x2) ---\nhpo.plot_metric_panels(study, metrics=[\"calibration_error\", \"nrmse\"])\nplt.tight_layout()\nplt.show()"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Phase 2 of the [multi-metric visualization plan](dev/plans/plan-multi-metric-plots.md): updates the quickstart notebook to use the new plot API from PR #5.

**Changes:**
- Replaced ad-hoc 1x3 figure (with inline optimization history code) with a **2x2 overview figure** using `plot_pareto_front`, `plot_metric_scatter`, `plot_optimization_history`, `plot_param_importance`
- Added **1x2 per-metric panels** figure using `plot_metric_panels`
- Updated section 3 markdown with a table explaining each panel
- Net -50 lines of notebook code (ad-hoc plot logic removed)

## Test Plan

- `pytest tests/test_visualization.py -v` — 26/26 pass (Phase 1 tests)
- Manual: re-run notebook end-to-end to verify all plots render correctly
- All lint errors are pre-existing (confirmed on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)