### PR TITLE
Add training TODO and validation note

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -18,6 +18,23 @@ Suggested execution order: I, then research follow-ups A2/A3.
 
 ---
 
+### Package K: Training Search-Space Follow-up
+
+Tracked in [issue #69](https://github.com/matthiaskloft/bayesflow-hpo/issues/69).
+PR #68 already made `batch_size` tunable, widened `initial_lr` to `1e-2`,
+and introduced coherent fixed-budget and open-ended training modes. Remaining
+work is to:
+
+1. Reparameterize learning rate relative to batch size so the search follows
+   the measured batch/learning-rate interaction instead of treating both axes
+   as independent.
+2. Derive `num_batches` from a fixed simulation budget, keeping comparisons
+   across sampled batch sizes simulation-matched.
+3. Keep warmup length fixed rather than adding another correlated search
+   dimension; evaluate alternative warmup fractions outside HPO first.
+
+---
+
 ### Package A2: Research — Detailed Sampler Preset Defaults
 
 The sampler presets are implemented (PR #56). This research task remains

--- a/src/bayesflow_hpo/validation/data.py
+++ b/src/bayesflow_hpo/validation/data.py
@@ -70,6 +70,13 @@ def generate_validation_dataset(
     Every batch is timed so that ``sim_time_per_sim`` reflects the
     average wall-clock cost of a single simulation across all
     conditions.
+
+    .. note::
+        When *condition_grid* is provided, each grid point is passed to
+        ``simulator.sample(..., conditions=condition)``. Simulators that use
+        a different mechanism to construct condition-specific samples cannot
+        use this path and must construct a :class:`ValidationDataset`
+        directly.
     """
     rng = np.random.default_rng(seed)
 


### PR DESCRIPTION
## Summary

- document the remaining Package K training search-space work tracked by #69
- clarify that condition-grid validation requires `simulator.sample(..., conditions=...)`
- direct incompatible simulators to construct `ValidationDataset` directly

## Test plan

- `KERAS_BACKEND=torch python -m pytest tests/ -v --tb=short` — 761 passed
- `ruff check src/ tests/` — clean
- `git diff --check` — clean

— Codex (GPT-5.6 Sol)